### PR TITLE
add workflow for running sheet fetch in CI

### DIFF
--- a/.github/workflows/gen-daily.yml
+++ b/.github/workflows/gen-daily.yml
@@ -1,0 +1,46 @@
+on: workflow_dispatch
+
+jobs:
+  datasets_gen_daily:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oven-sh/setup-bun@v1
+        name: setup bun
+        with:
+          bun-version: 1.0.22
+
+      - name: install dependencies
+        run: bun install
+
+      - name: generate daily datasets
+        run: bun run gen-daily
+        env:
+          TFP_SHEET_KEY: ${{ secrets.TFP_SHEET_KEY }}
+
+      - name: commit vars
+        id: commitvars
+        run: |
+          echo "currentdate=$(date '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+          echo "branchname=ci-workflow-$(date '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+        name: commit changes
+        env:
+          CURRENT_DATE: ${{ steps.commitvars.outputs.currentdate }}
+          NEW_BRANCH: ${{ steps.commitvars.outputs.branchname }}
+        with:
+          message: "daily: update for $CURRENT_DATE"
+          new_branch: "$NEW_BRANCH"
+          push: true
+
+      - name: create PR for review
+        env:
+          CURRENT_DATE: ${{ steps.commitvars.outputs.currentdate }}
+          NEW_BRANCH: ${{ steps.commitvars.outputs.branchname }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            -B main \
+            -H "$NEW_BRANCH" \
+            --title "daily: update for $CURRENT_DATE" \
+            --body 'Pulling new values from google sheet, triggered from CI workflow for review.'

--- a/scripts/utils/gsheets.ts
+++ b/scripts/utils/gsheets.ts
@@ -1,8 +1,3 @@
-const gsheetsKey = process.env.GSHEETS_KEY;
-
-// worksheet currently owned by @sterlingwes
-const sheetId = "1UuWRD602kUFyYbw-e6eJ3PaOGlyfMvwMBJW9zdGOO8g";
-
 export enum SheetTab {
   CasualtiesDaily = "casualties_daily",
   KilledInGaza = "martyrs",
@@ -12,8 +7,17 @@ type GSheetsResponse = {
   values: string[][]; // array of rows with array of column values
 };
 
+const token = process.env.TFP_SHEET_KEY ?? "";
+
 export const fetchGoogleSheet = async (sheetTab: SheetTab) => {
-  const sheetUrl = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${sheetTab}?alt=json&key=${gsheetsKey}`;
-  const response = await fetch(sheetUrl);
+  const sheetUrl = `https://tfp.fediship.workers.dev/?tab=${sheetTab}`;
+  if (!token) {
+    throw new Error(
+      "fetchGoogleSheet requires TFP_SHEET_KEY to be defined (which it should be in CI)"
+    );
+  }
+  const response = await fetch(sheetUrl, {
+    headers: { "x-token": token },
+  });
   return response.json() as Promise<GSheetsResponse>;
 };


### PR DESCRIPTION
allows for others to run the command that generates the daily data series updates from the worksheet without needing to configure google API keys

this makes the request to the google sheet through a proxy so i can manage my personal key independently of the one used to call the proxy and stored in repo actions secrets