### PR TITLE
docs: add example usage

### DIFF
--- a/site/docs/examples.mdx
+++ b/site/docs/examples.mdx
@@ -1,0 +1,13 @@
+---
+displayed_sidebar: docs
+---
+
+# Example Usage
+
+If you've used our data and are willing to share your usage, please [submit a PR or issue on Github](https://github.com/TechForPalestine/palestine-datasets).
+
+## Daily Casualties Dataset
+
+- Bar chart race ([View](https://hatemhosny.github.io/conflict-casualties/) | [Playground](https://livecodes.io/?x=id/5vjcrw2xdj8))
+- Summary count grid ([View](https://gazanumbers.jariyah.app/))
+- Line chart & count visualization ([View](https://genocide.club/talbroda))

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -68,6 +68,10 @@ const config: Config = {
           label: "Contributing",
         },
         {
+          to: "docs/examples/",
+          label: "Examples",
+        },
+        {
           href: repoUrl,
           label: "GitHub",
           position: "right",

--- a/site/sidebars.ts
+++ b/site/sidebars.ts
@@ -22,6 +22,11 @@ const sidebars: SidebarsConfig = {
       items: ["killed-in-gaza", "casualties-daily", "summary"],
     },
     {
+      type: "link",
+      label: "Example Usage",
+      href: "/docs/examples",
+    },
+    {
       type: "category",
       label: "Guides",
       link: {


### PR DESCRIPTION
concrete examples can be helpful for people trying to make sense of the data available or finding usage inspiration

adds /docs/examples and related sidebar & header nav items

closes #22 