### PR TITLE
fix(killed-in-gaza): do not write individual JSON

### DIFF
--- a/scripts/data/v2/derived/killed-indices.ts
+++ b/scripts/data/v2/derived/killed-indices.ts
@@ -119,29 +119,6 @@ const generate = () => {
     names: indices.english,
   });
 
-  const urlFamily = (familyEn: string) =>
-    encodeURIComponent(familyEn.replace(/[^a-zA-Z]+/g, "-").toLowerCase());
-  const familyNameIndex = Object.keys(indices.families).reduce(
-    (acc, familyEn) => ({
-      ...acc,
-      [familyEn]: urlFamily(familyEn),
-    }),
-    {} as Record<string, string>
-  );
-  Object.keys(familyNameIndex).forEach((familyEn) => {
-    const uriName = familyNameIndex[familyEn];
-    if (!uriName || familyEn.includes("/") || familyEn.includes("?")) {
-      return;
-    }
-    writeOffManifestJson(
-      `${writePath}/family-${uriName}.json`,
-      indices.families[familyEn]
-    );
-  });
-  writeOffManifestJson(
-    `${writePath}/families.json`,
-    Object.values(familyNameIndex)
-  );
   writeOffManifestJson(
     `${writePath}/families-list.json`,
     Object.values(indices.families).filter(


### PR DESCRIPTION
#91 had a deploy error that made me realize that cloudflare has a hard upper limit on number of files in a Pages deployment (20,000) and... we crossed it

Removing the extra records and just shipping what Mohamed wanted for now, then going to figure out if I should rollback the individual person records since we'll hit the limit again with a new list release with more names in the future.