### PR TITLE
doc page cleanup for clarity

### DIFF
--- a/scripts/data/v3/summary.ts
+++ b/scripts/data/v3/summary.ts
@@ -10,6 +10,8 @@ import westBankDailies from "../../../west_bank_daily.json";
 const [lastGazaReport] = gazaDailies.slice().reverse();
 const [lastWestBankReport] = westBankDailies.slice().reverse();
 
+const kigPageSize = 100;
+
 const genderAge = (
   record: (typeof killedPersons)[0]
 ): [Exclude<typeof gender, undefined>, Exclude<typeof ageGroup, undefined>] => {
@@ -40,9 +42,12 @@ const genderAge = (
 };
 const known_killed_in_gaza = killedPersons.reduce((acc, record) => {
   const [gender, ageGroup] = genderAge(record);
+  const recordCount = (acc.records ?? 0) + 1;
   return {
     ...acc,
-    records: (acc.records ?? 0) + 1,
+    records: recordCount,
+    pages: Math.ceil(recordCount / kigPageSize),
+    page_size: kigPageSize,
     [gender]: {
       ...acc[gender],
       [ageGroup]: (acc[gender]?.[ageGroup] ?? 0) + 1,

--- a/site/docs/killed-in-gaza.mdx
+++ b/site/docs/killed-in-gaza.mdx
@@ -14,22 +14,28 @@ import { DocWarningBubble } from "@site/src/components";
   consider](/updates/gaza-ministry-casualty-context/).
 </DocWarningBubble>
 
-import { KilledListCountLabel, KilledListExplorer } from "@site/src/components";
+import {
+  KilledListCountLabel,
+  KilledListExplorer,
+  KilledListPagingLabel,
+} from "@site/src/components";
 
 <KilledListCountLabel />
 <KilledListExplorer />
 
 ## Usage
 
-The dataset is available as a single JSON array with an object for each person killed in Gaza. You can also download in CSV format below.
+The dataset is available as a CSV and JSON array. Given the size of the dataset, the JSON array has grown too large to use anything other than our minified JSON. Even then, for new projects we recommend sequentially requesting segments of the dataset using our [Paging option](#paging).
 
 import { JSONFileLinks } from "@site/src/components";
 
-<JSONFileLinks resource="KilledInGaza_V2" />
+<JSONFileLinks resource="KilledInGaza_V2" minifiedOnly />
 
 ### Paging
 
-Given the size of this list, request times may be long. You can fetch the list incrementally in pages of 100 using the following format (keeping in mind that these pages may not have consistent ordering over time):
+<KilledListPagingLabel />
+
+You can dynamically fetch the current page size and number of pages using our [Summary JSON](/docs/summary/#killed-children-by-name-usage). We recommend fetching this resource before & after a sequential fetch to confirm that the page count was stable (makes sure the list wasn't updated while you were requesting all the pages).
 
 ```
 https://data.techforpalestine.org/api/v2/killed-in-gaza/page-1.json

--- a/site/docs/summary.mdx
+++ b/site/docs/summary.mdx
@@ -56,19 +56,21 @@ Has the latest cumulative values from the last daily report from our [West Bank 
 
 ### `known_killed_in_gaza`
 
-Has summary values showing the composition of names by gender & age grouping for our [Killed in Gaza dataset](/docs/killed-in-gaza):
+Has summary values showing the composition of names by gender & age grouping for the [Killed in Gaza dataset](/docs/killed-in-gaza):
 
-| field name    | value                                        |
-| ------------- | -------------------------------------------- |
-| records       | number of names in the list                  |
-| male.senior   | number of men aged 65 or older               |
-| male.adult    | number of men between 65 and 17, exclusive   |
-| male.child    | number of boys under 18                      |
-| male.no_age   | number of men with no birth date             |
-| female.senior | number of women aged 65 or older             |
-| female.adult  | number of women between 65 and 17, exclusive |
-| female.child  | number of girls under 18                     |
-| female.no_age | number of women with no birth date           |
+| field name    | value                                                                                |
+| ------------- | ------------------------------------------------------------------------------------ |
+| records       | number of names in the list                                                          |
+| pages         | number of pages in the [paged list API](/docs/killed-in-gaza/#paging)                |
+| page_size     | number of records in each page of the [paged list API](/docs/killed-in-gaza/#paging) |
+| male.senior   | number of men aged 65 or older                                                       |
+| male.adult    | number of men between 65 and 17, exclusive                                           |
+| male.child    | number of boys under 18                                                              |
+| male.no_age   | number of men with no birth date                                                     |
+| female.senior | number of women aged 65 or older                                                     |
+| female.adult  | number of women between 65 and 17, exclusive                                         |
+| female.child  | number of girls under 18                                                             |
+| female.no_age | number of women with no birth date                                                   |
 
 ### `known_press_killed_in_gaza`
 

--- a/site/i18n/en/code.json
+++ b/site/i18n/en/code.json
@@ -2,6 +2,9 @@
   "killed-in-gaza-names-count": {
     "message": "There are {count} in this list of names of those known to have been killed in Gaza since October 7, 2023. Of these, {femaleSenior} were senior ladies, {maleSenior} were senior men, {femaleAdult} were women, {maleAdult} were men, {femaleChild} were girls and {maleChild} were boys."
   },
+  "killed-in-gaza-names-paging": {
+    "message": "Given the size of this list, request times for the full list may be long. You can fetch the list incrementally in pages of {page_size} JSON objects using the following format. Pages are numbered from 1 to {page_count}, and the total number of pages will grow as the list grows in size. Please keep in mind that these pages will not have consistent ordering over time."
+  },
   "press-killed-in-gaza-names-count": {
     "message": "There are {count} in this list of names of journalists known to have been killed in Gaza since October 7, 2023."
   },

--- a/site/src/components/DatasetList/DatasetList.tsx
+++ b/site/src/components/DatasetList/DatasetList.tsx
@@ -45,6 +45,10 @@ const cardItem = (item: any): item is DatasetProps =>
   !!item.label && !!item.docId && !!item.href;
 
 const filterByQuery = (items: ReturnType<typeof filterDocCardListItems>) => {
+  if (typeof window !== "object" || !window.location) {
+    return { items, filtered: false };
+  }
+
   const params = new URLSearchParams(location.search);
 
   if (!params.get("chartdata")) {

--- a/site/src/components/DatasetList/DatasetList.tsx
+++ b/site/src/components/DatasetList/DatasetList.tsx
@@ -44,11 +44,35 @@ const CategoryDataset = ({ label, href }: any) => {
 const cardItem = (item: any): item is DatasetProps =>
   !!item.label && !!item.docId && !!item.href;
 
+const filterByQuery = (items: ReturnType<typeof filterDocCardListItems>) => {
+  const params = new URLSearchParams(location.search);
+
+  if (!params.get("chartdata")) {
+    return { items, filtered: false };
+  }
+
+  return {
+    filtered: true,
+    items: items.filter(
+      (item) => item.type === "link" && item.docId?.includes("daily")
+    ),
+  };
+};
+
 export const DatasetList = () => {
   const category = useCurrentSidebarCategory();
-  const items = filterDocCardListItems(category.items);
+  const { items, filtered } = filterByQuery(
+    filterDocCardListItems(category.items)
+  );
+
   return (
     <div>
+      {filtered && (
+        <div style={{ marginBottom: 20 }}>
+          <b>Filter applied:</b> Only showing datasets associated with the home
+          page chart. <a href="/docs/datasets">View all datasets</a>
+        </div>
+      )}
       {items.map((item, i) =>
         cardItem(item) ? (
           <Dataset key={item.docId} {...item} />

--- a/site/src/components/HomeDailyChart/HomeDailyChart.tsx
+++ b/site/src/components/HomeDailyChart/HomeDailyChart.tsx
@@ -235,32 +235,13 @@ export const HomeDailyChart = () => {
       </div>
       <div className={styles.chartFooterButtonsContainer}>
         <div className={styles.chartFooterButtons}>
-          <Button to="/docs/casualties-daily" type="secondary">
-            Learn more about these datasets
+          <Button to="/docs/datasets?chartdata=1" type="primary">
+            Get the daily numbers
           </Button>
           <div style={{ width: 10, height: 10 }} />
-          {gazaCsv && (
-            <Button
-              to={`/${gazaCsv.apiPath}/${gazaCsv.name}`}
-              type="primary"
-              newTab
-            >
-              Download Gaza CSV
-            </Button>
-          )}
-          <div style={{ width: 10, height: 10 }} />
-          {westBankCsv && (
-            <Button
-              to={`/${westBankCsv.apiPath}/${westBankCsv.name}`}
-              type="primary"
-              newTab
-            >
-              Download West Bank CSV
-            </Button>
-          )}
-        </div>
-        <div className={styles.chartFooterJsonMessage}>
-          (Also available as a JSON API)
+          <Button to="/docs/killed-in-gaza" type="primary">
+            Get the list of those killed
+          </Button>
         </div>
       </div>
     </div>

--- a/site/src/components/JSONFileLinks/index.tsx
+++ b/site/src/components/JSONFileLinks/index.tsx
@@ -4,12 +4,20 @@ import { ExternalLinkButton } from "../ExternalLinkButton";
 import { ApiResource } from "../../../../types/api.types";
 import { useResourcePaths } from "@site/src/lib/resource-paths";
 
-export const JSONFileLinks = ({ resource }: { resource: ApiResource }) => {
+export const JSONFileLinks = ({
+  resource,
+  minifiedOnly,
+}: {
+  resource: ApiResource;
+  minifiedOnly?: boolean;
+}) => {
   const { unminified, minified, csv, siteUrl } = useResourcePaths(resource);
+
+  const showUnminified = !minifiedOnly && unminified;
 
   return (
     <div>
-      {unminified && (
+      {showUnminified && (
         <ExternalLinkButton
           to={`/${unminified.apiPath}/${unminified.name}`}
           style={csv ? { marginRight: 20 } : undefined}
@@ -17,25 +25,44 @@ export const JSONFileLinks = ({ resource }: { resource: ApiResource }) => {
           {unminified.name}
         </ExternalLinkButton>
       )}
+
       {csv && (
         <ExternalLinkButton
           to={`/${csv.apiPath}/${csv.name}`}
-          buttonType="secondary"
+          buttonType={showUnminified ? "secondary" : "primary"}
+          style={minifiedOnly ? { marginRight: 20 } : undefined}
         >
           {csv.name}
+        </ExternalLinkButton>
+      )}
+      {minifiedOnly && (
+        <ExternalLinkButton
+          to={`/${minified.apiPath}/${minified.name}`}
+          buttonType="secondary"
+        >
+          {minified.name}
         </ExternalLinkButton>
       )}
       <div className={styles.codeBlocks}>
         {minified && (
           <>
-            <h3>Minified </h3>
+            <h3>Minified JSON </h3>
             <CodeBlock>{`${siteUrl}/${minified.apiPath}/${minified.name}`}</CodeBlock>
           </>
         )}
-        {unminified && (
+        {showUnminified && (
           <>
-            <h3>Unminified </h3>
+            <h3>Unminified JSON </h3>
             <CodeBlock>{`${siteUrl}/${unminified.apiPath}/${unminified.name}`}</CodeBlock>
+          </>
+        )}
+        {csv && (
+          <>
+            <h3>CSV </h3>
+            <CodeBlock>{`${siteUrl}/${csv.apiPath}/${csv.name}`}</CodeBlock>
+            <a href={`${siteUrl}/${csv.apiPath}/${csv.name}`} download>
+              Download CSV
+            </a>
           </>
         )}
       </div>

--- a/site/src/components/KilledListPagingLabel.tsx
+++ b/site/src/components/KilledListPagingLabel.tsx
@@ -1,0 +1,18 @@
+import { translate } from "@docusaurus/Translate";
+import previewData from "@site/src/generated/summary.json";
+
+const format = (count: number) => new Intl.NumberFormat().format(count);
+
+export const KilledListPagingLabel = () => {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      {translate(
+        { message: "killed-in-gaza-names-paging" },
+        {
+          page_size: format(previewData.known_killed_in_gaza.page_size),
+          page_count: format(previewData.known_killed_in_gaza.pages),
+        }
+      )}
+    </div>
+  );
+};

--- a/site/src/components/index.ts
+++ b/site/src/components/index.ts
@@ -8,5 +8,6 @@ export * from "./JSONFileLinks";
 export * from "./KilledHeaderMarquee";
 export * from "./KilledListExplorer";
 export * from "./KilledListCountLabel";
+export * from "./KilledListPagingLabel";
 export * from "./KilledPersonSearchResult";
 export * from "./PressKilledListCountLabel";

--- a/types/summary.types.ts
+++ b/types/summary.types.ts
@@ -73,6 +73,8 @@ export type PreviewDataV3 = {
   };
   known_killed_in_gaza: {
     records: number;
+    pages: number;
+    page_size: number;
     male: {
       senior: number;
       adult: number;


### PR DESCRIPTION
We've received some feedback that getting to the right data is either unclear or, in the case of the names list, it doesn't load. This change:

* makes it clearer how to get to the names list and which CSV we want people to download for that data type
* removes the KiG unminified JSON option which is too large
* nudges people towards using the paged list
* provides options for dynamically pulling the paged list details from the summary API
* cleans up entrypoints from the home page to make finding the datasets easier