### PR TITLE
feat: daily SQLite export via GitHub Actions

### DIFF
--- a/.github/workflows/sqlite-export.yml
+++ b/.github/workflows/sqlite-export.yml
@@ -49,7 +49,7 @@ jobs:
             | `infrastructure_damaged` | ~730 |
             | `_meta` | 3 |
 
-### Download
-curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite -o palestine-datasets.sqlite
-files: dist/palestine-datasets.sqlite
-make_latest: true
+            ### Download
+            curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite -o palestine-datasets.sqlite
+          files: dist/palestine-datasets.sqlite
+          make_latest: true

--- a/.github/workflows/sqlite-export.yml
+++ b/.github/workflows/sqlite-export.yml
@@ -1,0 +1,58 @@
+name: SQLite Export
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.22
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build SQLite
+        run: bun run gen-sqlite
+
+      - name: Get date
+        id: date
+        run: echo "today=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sqlite-latest
+          name: "SQLite Export — ${{ steps.date.outputs.today }}"
+          body: |
+            Daily SQLite export of all palestine-datasets JSON files.
+            Built: ${{ steps.date.outputs.today }}
+
+            ### Tables
+            | Table | Rows (approx) |
+            |-------|---------------|
+            | `casualties_daily` | ~900 |
+            | `west_bank_daily` | ~900 |
+            | `killed_in_gaza` | ~60k |
+            | `press_killed_in_gaza` | ~260 |
+            | `infrastructure_damaged` | ~730 |
+            | `_meta` | 3 |
+
+            ### Download
+```bash
+            curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite \
+              -o palestine-datasets.sqlite
+```
+          files: dist/palestine-datasets.sqlite
+          make_latest: true

--- a/.github/workflows/sqlite-export.yml
+++ b/.github/workflows/sqlite-export.yml
@@ -49,10 +49,7 @@ jobs:
             | `infrastructure_damaged` | ~730 |
             | `_meta` | 3 |
 
-            ### Download
-```bash
-            curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite \
-              -o palestine-datasets.sqlite
-```
-          files: dist/palestine-datasets.sqlite
-          make_latest: true
+### Download
+curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite -o palestine-datasets.sqlite
+files: dist/palestine-datasets.sqlite
+make_latest: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ ci-tmp/
 /downloads/
 /pdfservices-*
 /config/pdfservices-*
+
+dist/

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gen-infrastructure": "bun run scripts/data/v3/infrastructure-damaged.ts",
     "gen-csv": "bun run scripts/data/v2/derived/csv.ts && bun run scripts/data/v3/derived/csv.ts",
     "gen-all": "bun run gen-daily && bun run gen-killed && bun run gen-killed-press && bun run gen-derived",
+    "gen-sqlite": "bun run scripts/build/sqlite-export.ts",
     "chart-viz": "bun run site/src/components/HomeDailyChart/generator/chart-generator.ts",
     "chart-viz-dev": "bun --watch site/src/components/HomeDailyChart/generator/chart-generator.ts",
     "flightcheck": "bun run types && bun run reset-manifest && bun run gen-all && bun run docs-build && bun run docs-serve",

--- a/scripts/build/sqlite-export.ts
+++ b/scripts/build/sqlite-export.ts
@@ -1,0 +1,266 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "fs";
+
+const DB_PATH = "dist/palestine-datasets.sqlite";
+
+function collectKeys(rows: Record<string, unknown>[]): string[] {
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const k of Object.keys(row)) keys.add(k);
+  }
+  return [...keys];
+}
+
+function inferType(v: unknown): string {
+  if (typeof v === "number") return Number.isInteger(v) ? "INTEGER" : "REAL";
+  return "TEXT";
+}
+
+function toSQLite(v: unknown): string | number | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "boolean") return v ? 1 : 0;
+  if (typeof v === "number") return v;
+  if (typeof v === "string") return v;
+  return JSON.stringify(v);
+}
+
+function writeMetadata(db: Database) {
+  db.run(`DROP TABLE IF EXISTS _meta`);
+  db.run(`CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT)`);
+
+  const insert = db.prepare(`INSERT INTO _meta (key, value) VALUES (?, ?)`);
+  db.transaction(() => {
+    insert.run("built_at", new Date().toISOString());
+    insert.run("source", "https://github.com/TechForPalestine/palestine-datasets");
+    insert.run("script_version", "1.0.0");
+  })();
+
+  console.log(`  ✓ _meta`);
+}
+
+async function loadInfrastructureDamaged(db: Database) {
+  const raw: Record<string, unknown>[] = await Bun.file("infrastructure-damaged.json").json();
+
+  const rows = raw.map((row) => {
+    const flat: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+        for (const [vk, vv] of Object.entries(v as Record<string, unknown>)) {
+          flat[`${k}_${vk}`] = vv;
+        }
+      } else {
+        flat[k] = v;
+      }
+    }
+    return flat;
+  });
+
+  const keys = collectKeys(rows);
+
+  const typeMap: Record<string, string> = {};
+  for (const key of keys) {
+    for (const row of rows) {
+      if (row[key] != null) {
+        typeMap[key] = inferType(row[key]);
+        break;
+      }
+    }
+    typeMap[key] ??= "TEXT";
+  }
+
+  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
+  db.run(`DROP TABLE IF EXISTS infrastructure_damaged`);
+  db.run(`CREATE TABLE infrastructure_damaged (${colDefs}, PRIMARY KEY (report_date))`);
+
+  const placeholders = keys.map(() => "?").join(", ");
+  const insert = db.prepare(
+    `INSERT OR REPLACE INTO infrastructure_damaged (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+  );
+
+  db.transaction((items: Record<string, unknown>[]) => {
+    for (const row of items) {
+      insert.run(keys.map((k) => toSQLite(row[k])));
+    }
+  })(rows);
+
+  console.log(`  ✓ infrastructure_damaged: ${rows.length} rows, ${keys.length} cols`);
+}
+
+async function loadKilledInGaza(db: Database) {
+  const raw: unknown[][] = await Bun.file("killed-in-gaza-v3.json").json();
+
+  const [header, ...dataRows] = raw;
+  const keys = header as string[];
+
+  const rows = dataRows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    keys.forEach((k, i) => { obj[k] = (row as unknown[])[i]; });
+    return obj;
+  });
+
+  const typeMap: Record<string, string> = {};
+  for (const key of keys) {
+    for (const row of rows) {
+      if (row[key] != null) {
+        typeMap[key] = inferType(row[key]);
+        break;
+      }
+    }
+    typeMap[key] ??= "TEXT";
+  }
+
+  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
+  db.run(`DROP TABLE IF EXISTS killed_in_gaza`);
+  db.run(`CREATE TABLE killed_in_gaza (${colDefs}, PRIMARY KEY (id))`);
+
+  const placeholders = keys.map(() => "?").join(", ");
+  const insert = db.prepare(
+    `INSERT OR REPLACE INTO killed_in_gaza (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+  );
+
+  db.transaction((items: Record<string, unknown>[]) => {
+    for (const row of items) {
+      insert.run(keys.map((k) => toSQLite(row[k])));
+    }
+  })(rows);
+
+  console.log(`  ✓ killed_in_gaza: ${rows.length} rows, ${keys.length} cols`);
+}
+
+async function loadWestBankDaily(db: Database) {
+  const raw: Record<string, unknown>[] = await Bun.file("west_bank_daily.json").json();
+
+  // flatten: { report_date, verified: { killed, ... }, killed_cum, ... }
+  // → { report_date, verified_killed, ..., killed_cum, ... }
+  const rows = raw.map((row) => {
+    const flat: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (k === "verified" && typeof v === "object" && v !== null) {
+        for (const [vk, vv] of Object.entries(v as Record<string, unknown>)) {
+          flat[`verified_${vk}`] = vv;
+        }
+      } else {
+        flat[k] = v;
+      }
+    }
+    return flat;
+  });
+
+  const keys = collectKeys(rows);
+
+  const typeMap: Record<string, string> = {};
+  for (const key of keys) {
+    for (const row of rows) {
+      if (row[key] != null) {
+        typeMap[key] = inferType(row[key]);
+        break;
+      }
+    }
+    typeMap[key] ??= "TEXT";
+  }
+
+  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
+  db.run(`DROP TABLE IF EXISTS west_bank_daily`);
+  db.run(`CREATE TABLE west_bank_daily (${colDefs}, PRIMARY KEY (report_date))`);
+
+  const placeholders = keys.map(() => "?").join(", ");
+  const insert = db.prepare(
+    `INSERT OR REPLACE INTO west_bank_daily (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+  );
+
+  db.transaction((items: Record<string, unknown>[]) => {
+    for (const row of items) {
+      insert.run(keys.map((k) => toSQLite(row[k])));
+    }
+  })(rows);
+
+  console.log(`  ✓ west_bank_daily: ${rows.length} rows, ${keys.length} cols`);
+}
+
+async function loadCasualtiesDaily(db: Database) {
+  const rows: Record<string, unknown>[] = await Bun.file("casualties_daily.json").json();
+
+  const keys = collectKeys(rows);
+
+  const typeMap: Record<string, string> = {};
+  for (const key of keys) {
+    for (const row of rows) {
+      if (row[key] != null) {
+        typeMap[key] = inferType(row[key]);
+        break;
+      }
+    }
+    typeMap[key] ??= "TEXT";
+  }
+
+  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
+  db.run(`DROP TABLE IF EXISTS casualties_daily`);
+  db.run(`CREATE TABLE casualties_daily (${colDefs}, PRIMARY KEY (report_date))`);
+
+  const placeholders = keys.map(() => "?").join(", ");
+  const insert = db.prepare(
+    `INSERT OR REPLACE INTO casualties_daily (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+  );
+
+  const insertMany = db.transaction((items: Record<string, unknown>[]) => {
+    for (const row of items) {
+      insert.run(keys.map((k) => toSQLite(row[k])));
+    }
+  });
+
+  insertMany(rows);
+  console.log(`  ✓ casualties_daily: ${rows.length} rows, ${keys.length} cols`);
+}
+
+async function loadPressKilled(db: Database) {
+  const raw = Bun.file("press_killed_in_gaza.json");
+  const rows: Record<string, unknown>[] = await raw.json();
+
+  if (!rows.length) return;
+
+  const keys = Object.keys(rows[0]);
+  const colDefs = keys.map((k) => `"${k}" TEXT`).join(", ");
+
+  db.run(`DROP TABLE IF EXISTS press_killed_in_gaza`);
+  db.run(`CREATE TABLE press_killed_in_gaza (${colDefs})`);
+
+  const placeholders = keys.map(() => "?").join(", ");
+  const insert = db.prepare(
+    `INSERT INTO press_killed_in_gaza (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+  );
+
+  const insertMany = db.transaction((items: Record<string, unknown>[]) => {
+    for (const row of items) {
+      insert.run(keys.map((k) => String(row[k] ?? "")));
+    }
+  });
+
+  insertMany(rows);
+  console.log(`  ✓ press_killed_in_gaza: ${rows.length} rows`);
+};
+
+async function main() {
+  mkdirSync("dist", { recursive: true });
+
+  const db = new Database(DB_PATH);
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA synchronous = NORMAL");
+
+  try {
+      await loadPressKilled(db);
+      await loadCasualtiesDaily(db);
+      await loadWestBankDaily(db);
+      await loadKilledInGaza(db);
+      await loadInfrastructureDamaged(db);
+      writeMetadata(db);
+  } finally {
+    db.close();
+  }
+
+  console.log(`✅ ${DB_PATH}`);
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/build/sqlite-export.ts
+++ b/scripts/build/sqlite-export.ts
@@ -24,37 +24,12 @@ function toSQLite(v: unknown): string | number | null {
   return JSON.stringify(v);
 }
 
-function writeMetadata(db: Database) {
-  db.run(`DROP TABLE IF EXISTS _meta`);
-  db.run(`CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT)`);
-
-  const insert = db.prepare(`INSERT INTO _meta (key, value) VALUES (?, ?)`);
-  db.transaction(() => {
-    insert.run("built_at", new Date().toISOString());
-    insert.run("source", "https://github.com/TechForPalestine/palestine-datasets");
-    insert.run("script_version", "1.0.0");
-  })();
-
-  console.log(`  ✓ _meta`);
-}
-
-async function loadInfrastructureDamaged(db: Database) {
-  const raw: Record<string, unknown>[] = await Bun.file("infrastructure-damaged.json").json();
-
-  const rows = raw.map((row) => {
-    const flat: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(row)) {
-      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
-        for (const [vk, vv] of Object.entries(v as Record<string, unknown>)) {
-          flat[`${k}_${vk}`] = vv;
-        }
-      } else {
-        flat[k] = v;
-      }
-    }
-    return flat;
-  });
-
+function buildTable(
+  db: Database,
+  tableName: string,
+  rows: Record<string, unknown>[],
+  primaryKey?: string
+) {
   const keys = collectKeys(rows);
 
   const typeMap: Record<string, string> = {};
@@ -68,13 +43,15 @@ async function loadInfrastructureDamaged(db: Database) {
     typeMap[key] ??= "TEXT";
   }
 
+  const pkClause = primaryKey ? `, PRIMARY KEY (${primaryKey})` : "";
   const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
-  db.run(`DROP TABLE IF EXISTS infrastructure_damaged`);
-  db.run(`CREATE TABLE infrastructure_damaged (${colDefs}, PRIMARY KEY (report_date))`);
+
+  db.run(`DROP TABLE IF EXISTS "${tableName}"`);
+  db.run(`CREATE TABLE "${tableName}" (${colDefs}${pkClause})`);
 
   const placeholders = keys.map(() => "?").join(", ");
   const insert = db.prepare(
-    `INSERT OR REPLACE INTO infrastructure_damaged (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
+    `INSERT OR REPLACE INTO "${tableName}" (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
   );
 
   db.transaction((items: Record<string, unknown>[]) => {
@@ -83,55 +60,23 @@ async function loadInfrastructureDamaged(db: Database) {
     }
   })(rows);
 
-  console.log(`  ✓ infrastructure_damaged: ${rows.length} rows, ${keys.length} cols`);
+  console.log(`  ✓ ${tableName}: ${rows.length} rows, ${keys.length} cols`);
 }
 
-async function loadKilledInGaza(db: Database) {
-  const raw: unknown[][] = await Bun.file("killed-in-gaza-v3.json").json();
+async function loadPressKilled(db: Database) {
+  const rows: Record<string, unknown>[] = await Bun.file("press_killed_in_gaza.json").json();
+  buildTable(db, "press_killed_in_gaza", rows);
+}
 
-  const [header, ...dataRows] = raw;
-  const keys = header as string[];
-
-  const rows = dataRows.map((row) => {
-    const obj: Record<string, unknown> = {};
-    keys.forEach((k, i) => { obj[k] = (row as unknown[])[i]; });
-    return obj;
-  });
-
-  const typeMap: Record<string, string> = {};
-  for (const key of keys) {
-    for (const row of rows) {
-      if (row[key] != null) {
-        typeMap[key] = inferType(row[key]);
-        break;
-      }
-    }
-    typeMap[key] ??= "TEXT";
-  }
-
-  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
-  db.run(`DROP TABLE IF EXISTS killed_in_gaza`);
-  db.run(`CREATE TABLE killed_in_gaza (${colDefs}, PRIMARY KEY (id))`);
-
-  const placeholders = keys.map(() => "?").join(", ");
-  const insert = db.prepare(
-    `INSERT OR REPLACE INTO killed_in_gaza (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
-  );
-
-  db.transaction((items: Record<string, unknown>[]) => {
-    for (const row of items) {
-      insert.run(keys.map((k) => toSQLite(row[k])));
-    }
-  })(rows);
-
-  console.log(`  ✓ killed_in_gaza: ${rows.length} rows, ${keys.length} cols`);
+async function loadCasualtiesDaily(db: Database) {
+  const rows: Record<string, unknown>[] = await Bun.file("casualties_daily.json").json();
+  buildTable(db, "casualties_daily", rows, "report_date");
 }
 
 async function loadWestBankDaily(db: Database) {
   const raw: Record<string, unknown>[] = await Bun.file("west_bank_daily.json").json();
 
-  // flatten: { report_date, verified: { killed, ... }, killed_cum, ... }
-  // → { report_date, verified_killed, ..., killed_cum, ... }
+  // flatten nested "verified" object → verified_* prefix
   const rows = raw.map((row) => {
     const flat: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(row)) {
@@ -146,98 +91,59 @@ async function loadWestBankDaily(db: Database) {
     return flat;
   });
 
-  const keys = collectKeys(rows);
-
-  const typeMap: Record<string, string> = {};
-  for (const key of keys) {
-    for (const row of rows) {
-      if (row[key] != null) {
-        typeMap[key] = inferType(row[key]);
-        break;
-      }
-    }
-    typeMap[key] ??= "TEXT";
-  }
-
-  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
-  db.run(`DROP TABLE IF EXISTS west_bank_daily`);
-  db.run(`CREATE TABLE west_bank_daily (${colDefs}, PRIMARY KEY (report_date))`);
-
-  const placeholders = keys.map(() => "?").join(", ");
-  const insert = db.prepare(
-    `INSERT OR REPLACE INTO west_bank_daily (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
-  );
-
-  db.transaction((items: Record<string, unknown>[]) => {
-    for (const row of items) {
-      insert.run(keys.map((k) => toSQLite(row[k])));
-    }
-  })(rows);
-
-  console.log(`  ✓ west_bank_daily: ${rows.length} rows, ${keys.length} cols`);
+  buildTable(db, "west_bank_daily", rows, "report_date");
 }
 
-async function loadCasualtiesDaily(db: Database) {
-  const rows: Record<string, unknown>[] = await Bun.file("casualties_daily.json").json();
+async function loadKilledInGaza(db: Database) {
+  const raw: unknown[][] = await Bun.file("killed-in-gaza-v3.json").json();
 
-  const keys = collectKeys(rows);
+  // format: row 0 = headers, rows 1+ = data
+  const [header, ...dataRows] = raw;
+  const keys = header as string[];
 
-  const typeMap: Record<string, string> = {};
-  for (const key of keys) {
-    for (const row of rows) {
-      if (row[key] != null) {
-        typeMap[key] = inferType(row[key]);
-        break;
-      }
-    }
-    typeMap[key] ??= "TEXT";
-  }
-
-  const colDefs = keys.map((k) => `"${k}" ${typeMap[k]}`).join(", ");
-  db.run(`DROP TABLE IF EXISTS casualties_daily`);
-  db.run(`CREATE TABLE casualties_daily (${colDefs}, PRIMARY KEY (report_date))`);
-
-  const placeholders = keys.map(() => "?").join(", ");
-  const insert = db.prepare(
-    `INSERT OR REPLACE INTO casualties_daily (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
-  );
-
-  const insertMany = db.transaction((items: Record<string, unknown>[]) => {
-    for (const row of items) {
-      insert.run(keys.map((k) => toSQLite(row[k])));
-    }
+  const rows = dataRows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    keys.forEach((k, i) => { obj[k] = (row as unknown[])[i]; });
+    return obj;
   });
 
-  insertMany(rows);
-  console.log(`  ✓ casualties_daily: ${rows.length} rows, ${keys.length} cols`);
+  buildTable(db, "killed_in_gaza", rows, "id");
 }
 
-async function loadPressKilled(db: Database) {
-  const raw = Bun.file("press_killed_in_gaza.json");
-  const rows: Record<string, unknown>[] = await raw.json();
+async function loadInfrastructureDamaged(db: Database) {
+  const raw: Record<string, unknown>[] = await Bun.file("infrastructure-damaged.json").json();
 
-  if (!rows.length) return;
-
-  const keys = Object.keys(rows[0]);
-  const colDefs = keys.map((k) => `"${k}" TEXT`).join(", ");
-
-  db.run(`DROP TABLE IF EXISTS press_killed_in_gaza`);
-  db.run(`CREATE TABLE press_killed_in_gaza (${colDefs})`);
-
-  const placeholders = keys.map(() => "?").join(", ");
-  const insert = db.prepare(
-    `INSERT INTO press_killed_in_gaza (${keys.map((k) => `"${k}"`).join(", ")}) VALUES (${placeholders})`
-  );
-
-  const insertMany = db.transaction((items: Record<string, unknown>[]) => {
-    for (const row of items) {
-      insert.run(keys.map((k) => String(row[k] ?? "")));
+  // flatten nested category objects → category_field prefix
+  const rows = raw.map((row) => {
+    const flat: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+        for (const [vk, vv] of Object.entries(v as Record<string, unknown>)) {
+          flat[`${k}_${vk}`] = vv;
+        }
+      } else {
+        flat[k] = v;
+      }
     }
+    return flat;
   });
 
-  insertMany(rows);
-  console.log(`  ✓ press_killed_in_gaza: ${rows.length} rows`);
-};
+  buildTable(db, "infrastructure_damaged", rows, "report_date");
+}
+
+function writeMetadata(db: Database) {
+  db.run(`DROP TABLE IF EXISTS _meta`);
+  db.run(`CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT)`);
+
+  const insert = db.prepare(`INSERT INTO _meta (key, value) VALUES (?, ?)`);
+  db.transaction(() => {
+    insert.run("built_at", new Date().toISOString());
+    insert.run("source", "https://github.com/TechForPalestine/palestine-datasets");
+    insert.run("script_version", "1.0.0");
+  })();
+
+  console.log(`  ✓ _meta`);
+}
 
 async function main() {
   mkdirSync("dist", { recursive: true });
@@ -246,22 +152,19 @@ async function main() {
   db.run("PRAGMA journal_mode = WAL");
   db.run("PRAGMA synchronous = NORMAL");
 
-try {
+  try {
     await loadPressKilled(db);
     await loadCasualtiesDaily(db);
     await loadWestBankDaily(db);
     await loadKilledInGaza(db);
     await loadInfrastructureDamaged(db);
     writeMetadata(db);
-    const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
-    console.log("  tables:", tables.map((t) => t.name).join(", "));
+    console.log(`✅ ${DB_PATH}`);
   } finally {
     db.run("PRAGMA wal_checkpoint(TRUNCATE)");
     db.close();
   }
-
-  console.log(`✅ ${DB_PATH}`);
-};
+}
 
 main().catch((err) => {
   console.error(err);

--- a/scripts/build/sqlite-export.ts
+++ b/scripts/build/sqlite-export.ts
@@ -246,16 +246,17 @@ async function main() {
   db.run("PRAGMA journal_mode = WAL");
   db.run("PRAGMA synchronous = NORMAL");
 
-  try {
-      await loadPressKilled(db);
-      await loadCasualtiesDaily(db);
-      await loadWestBankDaily(db);
-      await loadKilledInGaza(db);
-      await loadInfrastructureDamaged(db);
-      writeMetadata(db);
-  } finally {
+try {
+    await loadPressKilled(db);
+    await loadCasualtiesDaily(db);
+    await loadWestBankDaily(db);
+    await loadKilledInGaza(db);
+    await loadInfrastructureDamaged(db);
+    writeMetadata(db);
     const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
     console.log("  tables:", tables.map((t) => t.name).join(", "));
+  } finally {
+    db.run("PRAGMA wal_checkpoint(TRUNCATE)");
     db.close();
   }
 

--- a/scripts/build/sqlite-export.ts
+++ b/scripts/build/sqlite-export.ts
@@ -254,6 +254,8 @@ async function main() {
       await loadInfrastructureDamaged(db);
       writeMetadata(db);
   } finally {
+    const tables = db.query("SELECT name FROM sqlite_master WHERE type='table'").all() as { name: string }[];
+    console.log("  tables:", tables.map((t) => t.name).join(", "));
     db.close();
   }
 


### PR DESCRIPTION
Adds a script and daily GitHub Action that converts all JSON datasets to a single SQLite file, published as a rolling release artifact.

### What this adds
- `scripts/build/sqlite-export.ts` — reads the JSON files locally and builds `dist/palestine-datasets.sqlite`
- `.github/workflows/sqlite-export.yml` — runs daily at 08:00 UTC, publishes to the `sqlite-latest` release tag
- `bun run gen-sqlite` script in `package.json`

### Schema decisions
- `casualties_daily` — single table, all columns nullable (handles schema drift over time)
- `west_bank_daily` — flattened with `verified_` prefix for OCHA nested fields
- `killed_in_gaza` — row 0 as header, remaining rows as data
- `infrastructure_damaged` — category objects flattened with category name as prefix
- `press_killed_in_gaza` — flat array, loaded as-is
- `_meta` — build metadata (built_at, source, script_version)

### Download
If merged, the artifact will be available at:
```bash
curl -L https://github.com/TechForPalestine/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite \
  -o palestine-datasets.sqlite
```

Currently running on my fork if you want to test it:
```bash
curl -L https://github.com/jusquicitoutvabien/palestine-datasets/releases/download/sqlite-latest/palestine-datasets.sqlite \
  -o palestine-datasets.sqlite
```