### PR TITLE
feat: add missing public type definitions and index

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,8 @@
+// Public types for external consumers of the Palestine Datasets API
+
+export type { CasualtyDailyReportV2 } from "./casualties-daily.types";
+export type { KilledInGaza, MarqueePerson } from "./killed-in-gaza.types";
+export type { PressKilledInGaza } from "./press-killed-in-gaza.types";
+export type { WestBankDailyReportV2, WestBankDailyVerified } from "./west-bank-daily.types";
+export type { InfrastructureDamagedV3, InfrastructureDamagedRecord, InfrastructureDamagedCivicBuildings, InfrastructureDamagedEducationalBuildings, InfrastructureDamagedPlacesOfWorship, InfrastructureDamagedResidential } from "./infrastructure-damaged.types";
+export type { PreviewDataV1, PreviewDataV2, PreviewDataV3 } from "./summary.types";

--- a/types/infrastructure-damaged.types.ts
+++ b/types/infrastructure-damaged.types.ts
@@ -1,0 +1,31 @@
+export type InfrastructureDamagedCivicBuildings = {
+  ext_destroyed?: number;
+  ext_damaged?: number;
+};
+
+export type InfrastructureDamagedEducationalBuildings = {
+  ext_destroyed?: number;
+  ext_damaged?: number;
+};
+
+export type InfrastructureDamagedPlacesOfWorship = {
+  ext_mosques_destroyed?: number;
+  ext_mosques_damaged?: number;
+  ext_churches_destroyed?: number;
+  ext_churches_damaged?: number;
+};
+
+export type InfrastructureDamagedResidential = {
+  ext_destroyed?: number;
+  ext_damaged?: number;
+};
+
+export type InfrastructureDamagedV3 = {
+  report_date: string;
+  civic_buildings?: InfrastructureDamagedCivicBuildings;
+  educational_buildings?: InfrastructureDamagedEducationalBuildings;
+  places_of_worship?: InfrastructureDamagedPlacesOfWorship;
+  residential?: InfrastructureDamagedResidential;
+};
+
+export type InfrastructureDamagedRecord = Record<string, InfrastructureDamagedV3>;

--- a/types/press-killed-in-gaza.types.ts
+++ b/types/press-killed-in-gaza.types.ts
@@ -1,0 +1,5 @@
+export type PressKilledInGaza = {
+  name: string;
+  name_en: string;
+  notes: string;
+};

--- a/types/west-bank-daily.types.ts
+++ b/types/west-bank-daily.types.ts
@@ -1,0 +1,21 @@
+export type WestBankDailyVerified = {
+  killed: number;
+  killed_cum: number;
+  injured: number;
+  injured_cum: number;
+  killed_children: number;
+  killed_children_cum: number;
+  injured_children: number;
+  injured_children_cum: number;
+};
+
+export type WestBankDailyReportV2 = {
+  report_date: string;
+  verified?: WestBankDailyVerified;
+  killed_cum: number;
+  killed_children_cum: number;
+  injured_cum: number;
+  injured_children_cum: number;
+  settler_attacks_cum: number;
+  flash_source: string;
+};


### PR DESCRIPTION
Adds type definitions for the three datasets that were missing them:
- `west_bank_daily` (most notable: the optional `verified` nested layer)
- `press_killed_in_gaza`
- `infrastructure-damaged`

Also adds `types/index.ts` to re-export all public types from a single entry point, making it easier for external developers to consume the types without digging into internal files.