### PR TITLE
Phase 5 CI: validate source-data PRs, build datasets on main

### DIFF
--- a/.github/workflows/casualties-build.yml
+++ b/.github/workflows/casualties-build.yml
@@ -1,0 +1,57 @@
+name: Daily casualties — build on main
+
+# When source data lands on main (e.g. a merged Decap CMS PR), regenerate the
+# Gaza & West Bank JSON datasets from it and commit them. No Google Sheet / no
+# TFP_SHEET_KEY is needed — these two datasets are now driven entirely by the
+# committed source_data files.
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "source_data/**"
+      - "scripts/data/v2/gaza-daily.ts"
+      - "scripts/data/v2/west-bank-daily.ts"
+      - "scripts/data/common/casualties-daily/**"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        name: setup bun
+        with:
+          bun-version: 1.0.22
+
+      - name: install dependencies
+        run: bun install
+
+      - name: regenerate datasets from source data
+        run: |
+          bun run gen-daily-v2
+          bun run gen-wbdaily
+
+      - name: commit regenerated JSON
+        id: commit
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: |
+            casualties_daily.json
+            casualties_daily.min.json
+            west_bank_daily.json
+            west_bank_daily.min.json
+          message: "data: regenerate Gaza & West Bank datasets from source_data"
+
+      - name: trigger SQLite export
+        # the JSON commit above uses GITHUB_TOKEN, which does not re-trigger the
+        # push-based sqlite-export, so dispatch it explicitly when JSON changed
+        if: steps.commit.outputs.committed == 'true'
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          event-type: sqlite-export

--- a/.github/workflows/casualties-pr-check.yml
+++ b/.github/workflows/casualties-pr-check.yml
@@ -1,0 +1,60 @@
+name: Daily casualties — PR check
+
+# Validates Gaza/West Bank source-data PRs (e.g. from the Decap CMS editorial
+# workflow). Read-only: it gates the merge but does not modify the PR branch.
+# The authoritative JSON regeneration happens on main (casualties-build.yml).
+
+on:
+  pull_request:
+    paths:
+      - "source_data/**"
+      - "scripts/data/v2/gaza-daily.ts"
+      - "scripts/data/v2/west-bank-daily.ts"
+      - "scripts/data/common/casualties-daily/**"
+      - ".github/workflows/casualties-pr-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        name: setup bun
+        with:
+          bun-version: 1.0.22
+
+      - name: install dependencies
+        run: bun install
+
+      - name: identify changed report files
+        id: changed
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'source_data/**/*.md' | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "Changed report files: ${files:-<none>}"
+
+      - name: validate reported vs cumulative consistency
+        # scoped to changed report dates (full series used for prior-day context);
+        # falls back to a full check when only build scripts changed
+        run: |
+          if [ -n "${{ steps.changed.outputs.files }}" ]; then
+            bun run validate-daily ${{ steps.changed.outputs.files }}
+          else
+            bun run validate-daily
+          fi
+
+      - name: regenerate datasets from source data
+        # gen scripts run validateDailiesJson, so this fails on malformed data
+        run: |
+          bun run gen-daily-v2
+          bun run gen-wbdaily
+
+      - name: show resulting dataset changes (informational)
+        run: git --no-pager diff --stat -- casualties_daily.json west_bank_daily.json || true

--- a/docs/decap-cms-setup.md
+++ b/docs/decap-cms-setup.md
@@ -16,10 +16,31 @@ Contributor → /admin (static Decap UI served by the Docusaurus site)
             → "Login with GitHub" → Cloudflare Worker OAuth proxy → GitHub
             → edits/creates one markdown file per report date under source_data/
             → editorial workflow opens a Pull Request
-PR CI       → regenerates casualties_daily.json / west_bank_daily.json from source_data
-            → runs typechecks + formatting → maintainer reviews & merges
-main        → existing SQLite export runs unchanged
+PR CI       → validates the changed report dates (casualties-pr-check.yml):
+              reported-vs-cumulative consistency + the source data builds
+main CI      → on merge, regenerates casualties_daily.json / west_bank_daily.json
+              from source_data and commits them (casualties-build.yml),
+              then triggers the SQLite export
 ```
+
+## Continuous integration
+
+Two workflows drive the source-data pipeline:
+
+- **`.github/workflows/casualties-pr-check.yml`** (on `pull_request`) — read-only
+  gate. It runs `validate-daily` scoped to the report dates the PR changed and
+  regenerates the datasets to confirm the source data is well-formed. It does not
+  modify the PR branch, so it never interferes with Decap's editorial-workflow
+  branches. A failure blocks the merge.
+- **`.github/workflows/casualties-build.yml`** (on `push` to `main`) — the
+  authoritative regeneration. It rebuilds the Gaza & West Bank JSON from
+  `source_data` and commits any changes, then dispatches the SQLite export. This
+  is also the safety net for source data that reaches main any other way (direct
+  edits, fork PRs).
+
+Neither needs `TFP_SHEET_KEY`: Gaza and West Bank are now built entirely from
+committed `source_data`. The Google Sheet (and `gen-daily.yml`) still drives the
+other datasets (infrastructure, press-killed).
 
 ## Content model
 


### PR DESCRIPTION
Adds the CI that drives the Decap source-data pipeline for Gaza & West Bank:

- casualties-pr-check.yml (pull_request): read-only gate. Runs validate-daily scoped to the report dates the PR changed (reported-vs-cumulative consistency) and regenerates the datasets to confirm the source data is well-formed. Does not touch the PR branch, so it never interferes with Decap editorial-workflow branches; a failure blocks merge.
- casualties-build.yml (push to main): authoritative regeneration. Rebuilds the Gaza & West Bank JSON from source_data, commits any changes, and dispatches the SQLite export. Also the safety net for source data reaching main any other way.

Neither needs TFP_SHEET_KEY — these two datasets are now built entirely from committed source_data. The Google Sheet still drives the other datasets.