### PR TITLE
fix(names): list column headers wrapping to their own line

### DIFF
--- a/site/src/components/KilledNamesListGrid/components/Header.tsx
+++ b/site/src/components/KilledNamesListGrid/components/Header.tsx
@@ -16,7 +16,7 @@ export const Header = React.memo(
     onPress: (col: (typeof kig3FieldIndex)[number]) => void;
   }) => {
     return (
-      <>
+      <div className={styles.headerRow}>
         {columnConfig.columns.map((col, index) => {
           let remappedContent: string = col;
           if (col === "en_name") {
@@ -64,7 +64,7 @@ export const Header = React.memo(
             </div>
           );
         })}
-      </>
+      </div>
     );
   },
 );

--- a/site/src/components/KilledNamesListGrid/killedNamesListGrid.module.css
+++ b/site/src/components/KilledNamesListGrid/killedNamesListGrid.module.css
@@ -134,11 +134,22 @@
   gap: 10px;
 }
 
+.headerRow {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
 .headerCell {
   background-color: var(--ifm-navbar-background-color);
   border-top: 2px solid var(--ifm-footer-bg-color);
   font-weight: 700;
-  display: inline-block;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 [data-theme="light"] .headerCell {


### PR DESCRIPTION
The header cells relied on plain inline-block flow with content-box sizing, so each cell's rendered width (weighted % of container plus its own padding/border) could exceed the container's total width by a few pixels — enough to make a cell wrap onto its own line, most visibly on narrower viewports like an unfolded Pixel Fold's square inner screen. Lay the header cells out in a non-wrapping flex row and size them with border-box so padding no longer pushes a row over its container width.
