### PR TITLE
feat: home chart tooltip event markers

### DIFF
--- a/site/src/components/HomeDailyChart/HomeDailyChartV2.styles.module.css
+++ b/site/src/components/HomeDailyChart/HomeDailyChartV2.styles.module.css
@@ -191,6 +191,13 @@
   position: relative;
 }
 
+/* An inline svg leaves baseline descender space below it, making this box
+   taller than the chart itself — which would slide the percentage-positioned
+   event markers and callout off the line, further the lower they sit. */
+.chartScrubArea svg {
+  display: block;
+}
+
 .chartCallout {
   position: absolute;
   width: 236px;

--- a/site/src/components/HomeDailyChart/HomeDailyChartV2.styles.module.css
+++ b/site/src/components/HomeDailyChart/HomeDailyChartV2.styles.module.css
@@ -193,26 +193,112 @@
 
 .chartCallout {
   position: absolute;
-  width: 214px;
-  max-width: 46%;
+  width: 236px;
+  max-width: 48%;
   background: var(--tfp-chart-callout-bg);
   color: var(--tfp-chart-callout-text);
   border-radius: 10px;
   padding: 10px 12px;
   box-shadow: 0 8px 24px rgba(20, 30, 25, 0.22);
   pointer-events: none;
+  z-index: 3;
+  transition: opacity 0.14s ease;
 }
 
+/* Anchored to the foot of the narrow chart: the line and its event markers
+   climb into the top half, so covering the fill costs the least. */
 .chartCalloutMobile {
   position: absolute;
   left: 0;
   right: 0;
-  top: 0;
+  bottom: 0;
   background: var(--tfp-chart-callout-bg);
   color: var(--tfp-chart-callout-text);
   border-radius: 10px;
   padding: 9px 11px;
   pointer-events: none;
+  z-index: 3;
+  transition: opacity 0.14s ease;
+}
+
+/* The callout belongs to the pointer: with nothing being scrubbed it goes
+   away rather than sitting on the chart claiming to describe "today". */
+.chartCalloutIdle {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.chartCalloutEvent {
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin-top: 4px;
+}
+
+.chartCalloutDetail {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  margin-top: 5px;
+  opacity: 0.78;
+}
+
+/* ---- key event markers ---- */
+.eventMarker {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  z-index: 2;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.eventMarkerDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tfp-chart-line);
+  box-shadow: 0 0 0 2px var(--tfp-chart-gradient-bottom-stop);
+  transition:
+    transform 0.12s ease,
+    background 0.12s ease;
+}
+
+.eventMarker:hover .eventMarkerDot,
+.eventMarkerActive .eventMarkerDot {
+  background: var(--tfp-chart-today-line);
+  transform: scale(1.4);
+}
+
+.eventMarker:focus-visible {
+  outline: 2px solid var(--tfp-chart-today-line);
+  outline-offset: 1px;
+  border-radius: 50%;
+}
+
+.chartHint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 30px;
+  font-size: 0.78rem;
+  line-height: 1.3;
+  color: var(--tfp-chart-subtitle);
+}
+
+.chartHintDot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tfp-chart-line);
+  box-shadow: 0 0 0 2px var(--tfp-chart-gradient-bottom-stop);
 }
 
 .chartCalloutDay {
@@ -295,5 +381,19 @@
 
   .chartColumn {
     padding-bottom: 14px;
+  }
+
+  .eventMarker {
+    width: 26px;
+    height: 26px;
+  }
+
+  .eventMarkerDot {
+    width: 9px;
+    height: 9px;
+  }
+
+  .chartHint {
+    margin-top: 26px;
   }
 }

--- a/site/src/components/HomeDailyChart/HomeDailyChartV2.tsx
+++ b/site/src/components/HomeDailyChart/HomeDailyChartV2.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import clsx from "clsx";
 import { parseISO } from "date-fns/parseISO";
 import { format } from "date-fns/format";
 import HomepageCasualtyChartV2 from "../../generated/daily-chart-v2";
@@ -13,6 +14,29 @@ const numFmt = new Intl.NumberFormat();
 const railValue = (n: number) => (n ? numFmt.format(n) : "—");
 
 const days = chartData.data.length;
+const lastDay = days - 1;
+
+// Key dated events baked in by the generator, with their marker positions in
+// svg coordinates (null where the marker was thinned out to avoid a clump).
+const events = chartData.events;
+const eventByDay = new Map(events.map((event) => [event.day, event]));
+
+// A single day is well under a pixel wide, so scrubbing would almost never
+// land exactly on an event. Snapping a few days either side makes the marked
+// dates reachable by pointer while leaving the rest of the chart scrubbable.
+const snapDays = 3;
+const snapToEvent = (day: number) => {
+  let closest = day;
+  let closestDistance = snapDays;
+  events.forEach((event) => {
+    const distance = Math.abs(event.day - day);
+    if (distance <= closestDistance) {
+      closestDistance = distance;
+      closest = event.day;
+    }
+  });
+  return closest;
+};
 
 let markerLine: SVGPathElement;
 let markerDot: SVGCircleElement;
@@ -58,19 +82,103 @@ const dayFromPointerX = (clientX: number, rect: DOMRect) => {
   return Math.round(fraction * (days - 1));
 };
 
+const eventDateLabel = (date: string) => format(parseISO(date), "MMMM d, yyyy");
+
+/**
+ * Dots on the line marking the key events, overlaid on the baked svg. They
+ * sit at a percentage of the chart box so they track the svg as it scales,
+ * and are real buttons so the dates are reachable by keyboard and by tap.
+ */
+const EventMarkers = ({
+  points,
+  width,
+  height,
+  activeDay,
+  onSelect,
+  onDismiss,
+}: {
+  points: (number[] | null)[];
+  width: number;
+  height: number;
+  activeDay: number | null;
+  onSelect: (day: number) => void;
+  onDismiss: () => void;
+}) => (
+  <>
+    {events.map((event, index) => {
+      const point = points[index];
+      if (!point) {
+        return null;
+      }
+      const [x, y] = point;
+      return (
+        <button
+          key={event.date}
+          type="button"
+          className={clsx(styles.eventMarker, activeDay === event.day && styles.eventMarkerActive)}
+          style={{ left: `${(x / width) * 100}%`, top: `${(y / height) * 100}%` }}
+          aria-label={`${eventDateLabel(event.date)}: ${event.title}`}
+          onClick={() => onSelect(event.day)}
+          onFocus={() => onSelect(event.day)}
+          onBlur={onDismiss}
+        >
+          <span className={styles.eventMarkerDot} aria-hidden="true" />
+        </button>
+      );
+    })}
+  </>
+);
+
 export const HomeDailyChartV2 = () => {
-  const dayRef = useRef(days - 1);
-  const [day, setDay] = useState(days - 1);
+  // null while the visitor isn't scrubbing: the rail falls back to the latest
+  // day and the callout stays hidden rather than lingering over the chart.
+  const [activeDay, setActiveDay] = useState<number | null>(null);
+  // A marker that was tapped or focused keeps its callout up after the
+  // pointer leaves, so the event text can actually be read on touch.
+  const [pinned, setPinned] = useState(false);
+  const dayRef = useRef<number | null>(null);
+
+  const day = activeDay ?? lastDay;
   const dayData = chartData.data[day];
+  const activeEvent = activeDay === null ? undefined : eventByDay.get(activeDay);
+
+  const setDay = (nextDay: number) => {
+    if (nextDay === dayRef.current) {
+      return;
+    }
+    dayRef.current = nextDay;
+    setActiveDay(nextDay);
+    moveMarker(nextDay);
+  };
 
   const onScrub = (e: React.PointerEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
-    const nextDay = dayFromPointerX(e.clientX, rect);
-    if (nextDay !== dayRef.current) {
-      dayRef.current = nextDay;
-      setDay(nextDay);
-      moveMarker(nextDay);
+    setPinned(false);
+    setDay(snapToEvent(dayFromPointerX(e.clientX, rect)));
+  };
+
+  // Back to rest: no callout, and the rail and marker return to the latest day.
+  const clearDay = () => {
+    dayRef.current = null;
+    setActiveDay(null);
+    moveMarker(lastDay);
+  };
+
+  const onLeave = () => {
+    if (pinned) {
+      return;
     }
+    clearDay();
+  };
+
+  const onSelectEvent = (eventDay: number) => {
+    setDay(eventDay);
+    setPinned(true);
+  };
+
+  const onDismissEvent = () => {
+    setPinned(false);
+    clearDay();
   };
 
   const dateLabel = format(parseISO(dayData.date), "MMMM do, yyyy");
@@ -79,6 +187,11 @@ export const HomeDailyChartV2 = () => {
   const calloutAnchor =
     calloutPct > 74 ? { right: 0 } : calloutPct < 4 ? { left: 0 } : { left: `${calloutPct - 4}%` };
   const calloutAbove = markY > chartData.height * 0.4;
+  // Anchored by the edge nearest the marker so the callout can grow downward
+  // (or upward) as event text is added without covering the point it marks.
+  const calloutPosition = calloutAbove
+    ? { bottom: `${(1 - (markY - 20) / chartData.height) * 100}%` }
+    : { top: `${((markY + 22) / chartData.height) * 100}%` };
 
   const railRows = [
     { label: "Injured", value: railValue(dayData.injured) },
@@ -91,6 +204,26 @@ export const HomeDailyChartV2 = () => {
     },
     { label: "First responders killed", value: railValue(dayData.civdef) },
   ];
+
+  const calloutBody = (
+    <>
+      <div className={styles.chartCalloutDay}>
+        Day {day + 1} &middot; {dateLabel}
+      </div>
+      {activeEvent && <div className={styles.chartCalloutEvent}>{activeEvent.title}</div>}
+      <div className={styles.chartCalloutStat}>
+        {numFmt.format(dayData.killed)} killed &middot; {numFmt.format(dayData.injured)} injured
+      </div>
+      {activeEvent && <div className={styles.chartCalloutDetail}>{activeEvent.detail}</div>}
+    </>
+  );
+
+  const chartHint = (
+    <div className={styles.chartHint}>
+      <span className={styles.chartHintDot} aria-hidden="true" />
+      <span>Key events — hover or drag across the chart for any day&apos;s numbers</span>
+    </div>
+  );
 
   const warningLink = (
     <a href="/updates/gaza-ministry-casualty-context/" className={styles.railFootnote}>
@@ -140,47 +273,58 @@ export const HomeDailyChartV2 = () => {
           <div className={styles.homeChartDesktop}>
             <div
               className={styles.chartScrubArea}
+              onPointerDown={onScrub}
               onPointerMove={onScrub}
+              onPointerLeave={onLeave}
+              onPointerCancel={onLeave}
               style={{ touchAction: "pan-y" }}
             >
               <HomepageCasualtyChartV2 style={{ width: "100%", height: "auto" }} />
+              <EventMarkers
+                points={chartData.eventPoints}
+                width={chartData.width}
+                height={chartData.height}
+                activeDay={activeDay}
+                onSelect={onSelectEvent}
+                onDismiss={onDismissEvent}
+              />
               <div
-                className={styles.chartCallout}
-                style={{
-                  ...calloutAnchor,
-                  top: calloutAbove
-                    ? `${((markY - 76) / chartData.height) * 100}%`
-                    : `${((markY + 22) / chartData.height) * 100}%`,
-                }}
+                className={clsx(styles.chartCallout, activeDay === null && styles.chartCalloutIdle)}
+                style={{ ...calloutAnchor, ...calloutPosition }}
               >
-                <div className={styles.chartCalloutDay}>
-                  Day {day + 1} &middot; {dateLabel}
-                </div>
-                <div className={styles.chartCalloutStat}>
-                  {numFmt.format(dayData.killed)} killed &middot; {numFmt.format(dayData.injured)}{" "}
-                  injured
-                </div>
+                {calloutBody}
               </div>
             </div>
           </div>
           <div className={styles.homeChartMobile}>
             <div
               className={styles.chartScrubArea}
+              onPointerDown={onScrub}
               onPointerMove={onScrub}
+              onPointerLeave={onLeave}
+              onPointerCancel={onLeave}
               style={{ touchAction: "pan-y" }}
             >
               <HomepageCasualtyChartV2Mobile style={{ width: "100%", height: "auto" }} />
-              <div className={styles.chartCalloutMobile}>
-                <div className={styles.chartCalloutDay}>
-                  Day {day + 1} &middot; {dateLabel}
-                </div>
-                <div className={styles.chartCalloutStat}>
-                  {numFmt.format(dayData.killed)} killed &middot; {numFmt.format(dayData.injured)}{" "}
-                  injured
-                </div>
+              <EventMarkers
+                points={chartData.mobile.eventPoints}
+                width={chartData.mobile.width}
+                height={chartData.mobile.height}
+                activeDay={activeDay}
+                onSelect={onSelectEvent}
+                onDismiss={onDismissEvent}
+              />
+              <div
+                className={clsx(
+                  styles.chartCalloutMobile,
+                  activeDay === null && styles.chartCalloutIdle,
+                )}
+              >
+                {calloutBody}
               </div>
             </div>
           </div>
+          {chartHint}
         </div>
       </div>
 

--- a/site/src/components/HomeDailyChart/generator/chart-generator-v2.ts
+++ b/site/src/components/HomeDailyChart/generator/chart-generator-v2.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import D3Node from "d3-node";
 import { transform } from "@svgr/core";
 import chartEvents from "./chart_events.json";
+import { keyEvents } from "./key-events";
 import gazaDailyTimeSeries from "../../../../../casualties_daily.min.json";
 import westBankDailyTimeSeries from "../../../../../west_bank_daily.min.json";
 import { CasualtyDailyReportV2 } from "../../../../../types/casualties-daily.types";
@@ -153,25 +154,72 @@ const data = gazaDailyTimeSeries.reduce(
   } as MappedData,
 );
 
+// Key dated events, resolved to their index in the daily series. Events whose
+// date has no matching report are dropped rather than silently misplaced.
+type PlottedEvent = {
+  day: number;
+  date: string;
+  title: string;
+  detail: string;
+};
+
+const dayIndexByDate = new Map(data.slimData.map(({ date }, index) => [date, index]));
+
+const plottedEvents: PlottedEvent[] = keyEvents
+  .map((event) => ({ ...event, day: dayIndexByDate.get(event.date) }))
+  .filter((event): event is PlottedEvent => typeof event.day === "number")
+  .sort((a, b) => a.day - b.day);
+
+const missingEventDates = keyEvents.filter((event) => !dayIndexByDate.has(event.date));
+if (missingEventDates.length) {
+  console.warn(
+    `chart-generator-v2: ignoring key events with no matching report date: ${missingEventDates
+      .map((event) => event.date)
+      .join(", ")}`,
+  );
+}
+
+// Markers closer together than this (in svg units) would overlap into an
+// unreadable clump, so the later one renders without a dot. The day is still
+// scrubbable and still names its event in the callout.
+const minMarkerGap = 11;
+
+const thinMarkers = (points: [number, number][]): ([number, number] | null)[] => {
+  let lastKeptX = -Infinity;
+  return points.map((point) => {
+    if (point[0] - lastKeptX < minMarkerGap) {
+      return null;
+    }
+    lastKeptX = point[0];
+    return point;
+  });
+};
+
 const json: {
   data: typeof data.slimData;
   width: number;
   height: number;
   dayPoints: [number, number][];
+  events: PlottedEvent[];
+  eventPoints: ([number, number] | null)[];
   mobile: {
     width: number;
     height: number;
     dayPoints: [number, number][];
+    eventPoints: ([number, number] | null)[];
   };
 } = {
   data: data.slimData,
   width: 0,
   height: 0,
   dayPoints: [],
+  events: plottedEvents,
+  eventPoints: [],
   mobile: {
     width: 0,
     height: 0,
     dayPoints: [],
+    eventPoints: [],
   },
 };
 
@@ -281,6 +329,10 @@ const render = async ({ mobile } = { mobile: false }) => {
     y(d.value) as number,
   ]);
 
+  // Marker positions for the key events, in the same svg coordinate space as
+  // dayPoints so the overlay can place them as a percentage of the chart box.
+  const eventPoints = thinMarkers(plottedEvents.map((event) => dayPoints[event.day]));
+
   helpers.addEventDotShadowFilter();
   helpers.addMarkerDotLine();
   helpers.addGradientDefinition();
@@ -311,6 +363,7 @@ const render = async ({ mobile } = { mobile: false }) => {
       width,
       height,
       dayPoints,
+      eventPoints,
     };
     // mobile is the last one to render so it renders the data json which backs both
     fs.writeFileSync(`site/src/generated/daily-chart-v2.json`, JSON.stringify(json));
@@ -318,6 +371,7 @@ const render = async ({ mobile } = { mobile: false }) => {
     json.width = width;
     json.height = height;
     json.dayPoints = dayPoints;
+    json.eventPoints = eventPoints;
   }
 };
 

--- a/site/src/components/HomeDailyChart/generator/key-events.ts
+++ b/site/src/components/HomeDailyChart/generator/key-events.ts
@@ -1,0 +1,111 @@
+/**
+ * Key dated events plotted as markers on the v2 homepage chart.
+ *
+ * Each entry must line up with a `report_date` in the daily casualties series
+ * (any date missing from the series is dropped at generate time). Keep the
+ * list chronological, the `title` short enough to headline a tooltip, and the
+ * `detail` to a single factual sentence — the point is to put the day's
+ * numbers in context, not to narrate the war.
+ *
+ * Markers that would collide are thinned out per-viewport by the generator,
+ * so adding a closely-spaced entry degrades gracefully: the marker may be
+ * dropped on the narrow chart, but scrubbing onto the date still surfaces it.
+ */
+export type KeyEvent = {
+  /** YYYY-MM-DD, matching a report_date in casualties_daily */
+  date: string;
+  title: string;
+  detail: string;
+};
+
+export const keyEvents: KeyEvent[] = [
+  {
+    date: "2023-10-07",
+    title: "Attack on southern Israel",
+    detail:
+      "Hamas leads an attack from Gaza killing about 1,200 people and taking over 240 hostages. Israel declares war and cuts off water, food, fuel and electricity to Gaza.",
+  },
+  {
+    date: "2023-10-27",
+    title: "Ground invasion begins",
+    detail: "Israeli forces launch a ground invasion of the Gaza Strip.",
+  },
+  {
+    date: "2023-11-24",
+    title: "First truce",
+    detail:
+      "A week-long truce and captive-prisoner exchange begins. Fighting resumes on December 1.",
+  },
+  {
+    date: "2023-12-29",
+    title: "Genocide case filed at the ICJ",
+    detail:
+      "South Africa files a case against Israel at the International Court of Justice alleging acts of genocide.",
+  },
+  {
+    date: "2024-01-26",
+    title: "ICJ orders provisional measures",
+    detail:
+      "The court finds it plausible that Israel's actions amount to genocide and orders measures to prevent them.",
+  },
+  {
+    date: "2024-02-29",
+    title: "The flour massacre",
+    detail: "Over 100 Palestinians are killed near Gaza City while waiting for food aid.",
+  },
+  {
+    date: "2024-03-18",
+    title: "Al-Shifa hospital raid",
+    detail: "Israeli forces begin a two-week raid on Gaza's largest hospital complex.",
+  },
+  {
+    date: "2024-05-06",
+    title: "Rafah offensive",
+    detail:
+      "Israel orders eastern Rafah to evacuate and takes the crossing into Egypt, closing a main aid route.",
+  },
+  {
+    date: "2024-10-06",
+    title: "Siege of northern Gaza",
+    detail:
+      "A renewed offensive seals off Jabalia and the northern towns, cutting them off for months.",
+  },
+  {
+    date: "2024-11-21",
+    title: "ICC arrest warrants",
+    detail:
+      "The International Criminal Court issues arrest warrants for Israel's prime minister and former defence minister.",
+  },
+  {
+    date: "2025-01-19",
+    title: "Ceasefire takes effect",
+    detail: "A ceasefire and captive-prisoner exchange deal pauses the fighting.",
+  },
+  {
+    date: "2025-03-02",
+    title: "All aid blocked",
+    detail: "Israel halts every shipment of aid into Gaza, beginning a total blockade.",
+  },
+  {
+    date: "2025-03-18",
+    title: "Ceasefire collapses",
+    detail: "Israel resumes large-scale strikes across Gaza, ending the January ceasefire.",
+  },
+  {
+    date: "2025-05-27",
+    title: "Aid moves to militarised sites",
+    detail:
+      "Distribution shifts to a handful of Gaza Humanitarian Foundation sites; killings of people seeking aid climb steeply from here.",
+  },
+  {
+    date: "2025-08-22",
+    title: "Famine confirmed",
+    detail: "The IPC declares famine in Gaza governorate, the first ever confirmed in the region.",
+  },
+  {
+    date: "2025-10-10",
+    title: "Ceasefire takes effect",
+    detail:
+      "A US-brokered ceasefire begins and the remaining living hostages are released days later.",
+  },
+];


### PR DESCRIPTION
Iterate on new design for the casualties time series chart on the home page. Still only renders with the `newChart=1` query param during testing 